### PR TITLE
MANTA-4628 Rename extant buckets components such that the name reflects the function

### DIFF
--- a/sapi_manifests/waferlock/template
+++ b/sapi_manifests/waferlock/template
@@ -55,7 +55,7 @@
 		"sapi_services": [
 			"manta/moray",
 			"manta/postgres",
-			"manta/boray",
+			"manta/buckets-mdapi",
 			"manta/buckets-postgres"
 		],
 		"shard": "{{{SHARD}}}",


### PR DESCRIPTION
Rename boray to buckets-mdapi in the SAPI template